### PR TITLE
Fixed Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ In this project you'll build an app that will keep track of memebers of a team. 
 - [ ] Create a forked copy of this project.
 - [ ] Add your team lead as collaborator on Github.
 - [ ] Clone your OWN version of the repository in your terminal
-- [ ] CD into the project base directory `cd american-football-scoreboard`
-- [ ] Download project dependencies by running one of these two commands `yarn` or `npm install`
+- [ ] Use `npx create-react-app team-builder` or `create-react-app team-builder` to initiate the project.
+- [ ] CD into your `team-builder` directory
 - [ ] Using the same command tool (yarn or npm) start up the app using `yarn start` or `npm start`
 - [ ] Create a new branch: git checkout -b `<firstName-lastName>`.
 - [ ] Implement the project on your newly created `<firstName-lastName>` branch, committing changes regularly.


### PR DESCRIPTION
The instructions for the app is using the instructions from another project.  I have updated the `README` to reflect that we need to use `npx create-react-app` or `create-react-app` so that the project can be bootstrapped with CRA.